### PR TITLE
fix: use different class name for product card images

### DIFF
--- a/src/components/ProductCard.css
+++ b/src/components/ProductCard.css
@@ -27,7 +27,7 @@
   }
 }
 
-.product-image {
+.product-item-image {
   max-height: 200px;
   object-fit: contain;
   width: 100%;

--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -24,7 +24,7 @@ export default function ProductCard({ product }) {
         src={product.image}
         alt={product.title}
         title={product.title}
-        className="product-image"
+        className="product-item-image"
       />
       <h4 className="product-name">{product.title}</h4>
       {enabled && (


### PR DESCRIPTION
## Details

Use a different class name for product card images to avoid image class name collisions.